### PR TITLE
Add lingui.config.ts support

### DIFF
--- a/src/lib/command/base.ts
+++ b/src/lib/command/base.ts
@@ -27,11 +27,23 @@ export default abstract class BaseCommand extends Command {
    */
   protected async getConfigFile(projectDir: string) {
     const isProjectDirAFile = await isFile(projectDir)
-    const linguiConfigFilePath = path.resolve(projectDir, isProjectDirAFile ? '' : 'lingui.config.js')
-    const isLinguiConfigFileReadable = await canReadFile(linguiConfigFilePath)
 
-    invariant(isLinguiConfigFileReadable, 'missing_lingui_config_file')
+    if (isProjectDirAFile) {
+      const linguiConfigFilePath = path.resolve(projectDir)
+      const isLinguiConfigFileReadable = await canReadFile(linguiConfigFilePath)
+      invariant(isLinguiConfigFileReadable, 'missing_lingui_config_file')
+      return {directory: path.dirname(linguiConfigFilePath), file: linguiConfigFilePath}
+    }
 
-    return {directory: path.dirname(linguiConfigFilePath), file: linguiConfigFilePath}
+    const tsConfigPath = path.resolve(projectDir, 'lingui.config.ts')
+    if (await canReadFile(tsConfigPath)) {
+      return {directory: path.dirname(tsConfigPath), file: tsConfigPath}
+    }
+
+    const jsConfigPath = path.resolve(projectDir, 'lingui.config.js')
+    const isJsConfigReadable = await canReadFile(jsConfigPath)
+    invariant(isJsConfigReadable, 'missing_lingui_config_file')
+
+    return {directory: path.dirname(jsConfigPath), file: jsConfigPath}
   }
 }

--- a/src/lib/command/invariant.ts
+++ b/src/lib/command/invariant.ts
@@ -18,7 +18,7 @@ export const invariantErrorMessage: Record<InvariantErrorCode, string> = {
   'llm:config:no_provider':
     'Provider missing from Linguito configuration. Please configure a provider using the "config" command',
   'llm:no_models_found': 'No models loaded in your LLM service',
-  missing_lingui_config_file: 'lingui.config.js does not exist or is not readable',
+  missing_lingui_config_file: 'lingui.config.ts or lingui.config.js does not exist or is not readable',
   unknown_catalog_file_format: 'Translation files must be in a known format. Currently supported formats are: po',
 }
 


### PR DESCRIPTION
## Description
Added support for .ts lingui configuration files, while keeping .js configuration file as a fallback option.